### PR TITLE
Add link to 2024's session

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -102,7 +102,7 @@
                 The Privacy & Personal Data Management Session aims to bring together technical and legal-ethical experts to discuss 
                 Solid as a concrete system for data governance, to ground the debate on emergent problems from both a technical 
                 perspective and a legal-ethical perspective of data protection. The first two editions of this Session were co-located 
-                with the Solid Symposium 2023 and 2024 and were hosted in Nürnberg, Germany, and Leuven, Belgium, respectively.
+                with the Solid Symposium 2023 and 2024 and were hosted in Nürnberg, Germany, and <a href=https://solidweb.me/besteves4/sosy24-privacy/privacy-session.html>Leuven, Belgium</a>, respectively.
                 The previous editions explored privacy-related problems concerning identity management, security, and authorization 
                 in Solid from an interdisciplinary perspective. 
             </p>


### PR DESCRIPTION
Not sure if this is necessary, as 2023 doesn't have its specific link to the session.